### PR TITLE
Add classic CPU segmentation to Streamlit app

### DIFF
--- a/classic_seg.py
+++ b/classic_seg.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+"""Classic, CPU-friendly segmentation methods for ZO-1 images.
+
+This module provides lightweight image segmentation routines that
+approximate the behaviour of the deep learning models used elsewhere in the
+app but run entirely on the CPU.  Three algorithms are provided: Gaussian
+Mixture Models (GMM), K-means clustering, and Otsu/adaptive thresholding.
+
+Each function expects an 8-bit single channel image (``img_u8``).  Colour
+images should be converted to grayscale before calling these functions.
+The functions return a label image where each integer corresponds to a cell,
+the binary membrane mask used for seeding, and a dictionary of basic
+summary statistics (cell count and mean/median area/diameter).
+
+Example
+-------
+>>> labels, membrane, stats = segment_zo1_gmm(img)
+"""
+
+from dataclasses import dataclass
+from typing import Dict, Tuple, Optional
+
+import numpy as np
+import cv2
+from skimage import filters, morphology, segmentation, measure, feature, util
+from sklearn.mixture import GaussianMixture
+from sklearn.cluster import KMeans
+
+
+@dataclass
+class SegmentationResult:
+    """Container for segmentation output."""
+
+    labels: np.ndarray  # int32 labelled image
+    membrane: np.ndarray  # bool membrane mask
+    stats: Dict[str, float]
+
+
+def _postprocess_and_watershed(
+    mem_mask: np.ndarray,
+    img_u8: np.ndarray,
+    min_obj: int = 200,
+    min_peak_dist: int = 8,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Refine membrane mask and apply watershed to obtain cell labels."""
+
+    mem = morphology.remove_small_objects(mem_mask.astype(bool), min_size=50)
+    mem = morphology.binary_closing(mem, morphology.disk(1))
+    mem = morphology.binary_dilation(mem, morphology.disk(1))
+    mem = mem.astype(np.uint8)
+
+    inside = 1 - mem
+    dist = cv2.distanceTransform(inside, cv2.DIST_L2, 3)
+    dist_supp = cv2.GaussianBlur(dist, (0, 0), 1.0)
+    peaks = feature.peak_local_max(
+        dist_supp,
+        labels=inside.astype(bool),
+        min_distance=min_peak_dist,
+        exclude_border=False,
+    )
+    markers = np.zeros_like(img_u8, dtype=np.int32)
+    for i, (r, c) in enumerate(peaks, start=1):
+        markers[r, c] = i
+    markers = morphology.dilation(markers, morphology.disk(1))
+
+    grad = filters.sobel(img_u8)
+    lab = segmentation.watershed(grad, markers=markers, mask=inside.astype(bool))
+    lab = morphology.remove_small_objects(lab, min_size=min_obj)
+    return lab.astype(np.int32), mem.astype(bool)
+
+
+def compute_cell_metrics(
+    labels: np.ndarray, pixel_size: Optional[float] = None
+) -> Tuple['pd.DataFrame', Dict[str, float]]:
+    """Compute per-cell metrics and summary statistics."""
+
+    import pandas as pd
+
+    props = measure.regionprops_table(
+        labels,
+        properties=(
+            'label',
+            'area',
+            'perimeter',
+            'equivalent_diameter',
+            'centroid',
+            'eccentricity',
+        ),
+    )
+    df = pd.DataFrame(props)
+
+    stats = {
+        'n_cells': int(len(df)),
+        'mean_area': float(df['area'].mean()) if len(df) else 0.0,
+        'median_area': float(df['area'].median()) if len(df) else 0.0,
+        'mean_equiv_diam': float(df['equivalent_diameter'].mean()) if len(df) else 0.0,
+        'median_equiv_diam': float(df['equivalent_diameter'].median()) if len(df) else 0.0,
+    }
+
+    if pixel_size and pixel_size > 0:
+        df['area_um2'] = df['area'] * (pixel_size ** 2)
+        df['equivalent_diameter_um'] = df['equivalent_diameter'] * pixel_size
+        stats.update(
+            {
+                'mean_area_um2': float(df['area_um2'].mean()) if len(df) else 0.0,
+                'median_area_um2': float(df['area_um2'].median()) if len(df) else 0.0,
+                'mean_equiv_diam_um': float(df['equivalent_diameter_um'].mean()) if len(df) else 0.0,
+                'median_equiv_diam_um': float(df['equivalent_diameter_um'].median()) if len(df) else 0.0,
+            }
+        )
+
+    return df, stats
+
+
+def _apply_ridge(img: np.ndarray) -> np.ndarray:
+    """Enhance thin membranes using a ridge filter."""
+
+    ridge = filters.sato(img.astype(float), sigmas=(1, 2, 3))
+    ridge = ridge > np.percentile(ridge, 70)
+    return ridge.astype(np.uint8)
+
+
+def segment_zo1_gmm(
+    img_u8: np.ndarray,
+    min_obj: int = 200,
+    smooth_sigma: float = 1.0,
+    use_ridge: bool = True,
+    min_peak_dist: int = 8,
+) -> SegmentationResult:
+    """Segment membranes using a Gaussian Mixture Model on intensities."""
+
+    blur = cv2.GaussianBlur(img_u8, (0, 0), smooth_sigma)
+    X = blur.reshape(-1, 1).astype(np.float32)
+    gmm = GaussianMixture(n_components=2, covariance_type='full', random_state=0).fit(X)
+    means = gmm.means_.flatten()
+    bright_idx = np.argmax(means)
+    labels = (gmm.predict(X) == bright_idx).reshape(blur.shape).astype(np.uint8)
+
+    mem = cv2.bitwise_and(labels, _apply_ridge(blur)) if use_ridge else labels
+    lab, mem_proc = _postprocess_and_watershed(mem, blur, min_obj, min_peak_dist)
+    _, stats = compute_cell_metrics(lab)
+    return SegmentationResult(lab, mem_proc, stats)
+
+
+def segment_zo1_kmeans(
+    img_u8: np.ndarray,
+    min_obj: int = 200,
+    smooth_sigma: float = 1.0,
+    use_ridge: bool = True,
+    min_peak_dist: int = 8,
+) -> SegmentationResult:
+    """Segment membranes using K-means clustering on intensities."""
+
+    blur = cv2.GaussianBlur(img_u8, (0, 0), smooth_sigma)
+    X = blur.reshape(-1, 1).astype(np.float32)
+    km = KMeans(n_clusters=2, n_init=10, random_state=0).fit(X)
+    centers = km.cluster_centers_.flatten()
+    bright_idx = np.argmax(centers)
+    labels = (km.labels_ == bright_idx).reshape(blur.shape).astype(np.uint8)
+
+    mem = cv2.bitwise_and(labels, _apply_ridge(blur)) if use_ridge else labels
+    lab, mem_proc = _postprocess_and_watershed(mem, blur, min_obj, min_peak_dist)
+    _, stats = compute_cell_metrics(lab)
+    return SegmentationResult(lab, mem_proc, stats)
+
+
+def segment_zo1_otsu(
+    img_u8: np.ndarray,
+    adaptive: bool = False,
+    block: int = 51,
+    offset: float = 0.0,
+    min_obj: int = 200,
+    smooth_sigma: float = 1.0,
+    use_ridge: bool = True,
+    min_peak_dist: int = 8,
+) -> SegmentationResult:
+    """Segment membranes using Otsu or adaptive thresholding."""
+
+    blur = cv2.GaussianBlur(img_u8, (0, 0), smooth_sigma)
+    if adaptive:
+        if block % 2 == 0:
+            block += 1  # ensure odd
+        thresh = filters.threshold_local(blur, block_size=block, offset=offset)
+    else:
+        thresh = filters.threshold_otsu(blur)
+    labels = (blur > thresh).astype(np.uint8)
+
+    mem = cv2.bitwise_and(labels, _apply_ridge(blur)) if use_ridge else labels
+    lab, mem_proc = _postprocess_and_watershed(mem, blur, min_obj, min_peak_dist)
+    _, stats = compute_cell_metrics(lab)
+    return SegmentationResult(lab, mem_proc, stats)
+


### PR DESCRIPTION
## Summary
- add `classic_seg` module implementing GMM, K-means and Otsu-based membrane segmentation with per-cell metrics
- wire classic segmentation into Streamlit UI with parameter controls, overlay preview, CSV and report downloads
- allow analysis pipeline to run on CPU-only classic labels

## Testing
- `python -m py_compile classic_seg.py app.py`
- `python - <<'PY'
import numpy as np, cv2
from classic_seg import segment_zo1_gmm, segment_zo1_kmeans, segment_zo1_otsu
img=np.zeros((64,64),dtype=np.uint8)
cv2.circle(img,(32,32),20,255,2)
for func in [segment_zo1_gmm, segment_zo1_kmeans, segment_zo1_otsu]:
    res=func(img)
    print(func.__name__, res.stats['n_cells'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab13fa88a08326b61bd93d4a9abc44