### PR TITLE
Add salt-and-pepper noise prefiltering before peak detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -135,6 +135,7 @@ def apply_otsu_mask(img, strength=1.0):
 # Peak detection-based quantification functions
 def ris_segfree(img_gray,
                 use_premask=True, premask_strength=1.0,
+                denoise_size=3, gauss_sigma=1.0,
                 smooth_window=9, z_thresh=2.0, min_sep=10,
                 initial_area_pct=10.0, max_area_pct=70.0, steps=5):
     """RIS quantification using peak detection along circular sampling paths."""
@@ -143,6 +144,16 @@ def ris_segfree(img_gray,
     mask_used = None
     if use_premask:
         work, mask_used = apply_otsu_mask(img_gray, strength=premask_strength)
+
+    # Median prefilter to remove salt-and-pepper noise
+    work_u8 = np.clip(work, 0, 255).astype(np.uint8)
+    if denoise_size and denoise_size > 1:
+        if denoise_size % 2 == 0:
+            denoise_size += 1
+        work_u8 = cv2.medianBlur(work_u8, denoise_size)
+
+    # Gaussian smoothing for stability
+    work = cv2.GaussianBlur(work_u8, (0, 0), gauss_sigma).astype(np.float32)
 
     A = H*W
     r0 = np.sqrt((initial_area_pct/100.0 * A)/np.pi)
@@ -177,6 +188,7 @@ def ris_segfree(img_gray,
 
 def tijor_segfree(img_gray,
                   use_premask=True, premask_strength=1.0,
+                  denoise_size=3, gauss_sigma=1.0,
                   smooth_window=9, z_thresh=2.0, min_sep=10,
                   initial_area_pct=10.0, max_area_pct=70.0, steps=5):
     """TiJOR quantification using peak detection along rectangular sampling paths."""
@@ -185,6 +197,16 @@ def tijor_segfree(img_gray,
     mask_used = None
     if use_premask:
         work, mask_used = apply_otsu_mask(img_gray, strength=premask_strength)
+
+    # Median prefilter for salt-and-pepper noise
+    work_u8 = np.clip(work, 0, 255).astype(np.uint8)
+    if denoise_size and denoise_size > 1:
+        if denoise_size % 2 == 0:
+            denoise_size += 1
+        work_u8 = cv2.medianBlur(work_u8, denoise_size)
+
+    # Gaussian smoothing
+    work = cv2.GaussianBlur(work_u8, (0, 0), gauss_sigma).astype(np.float32)
 
     A = H*W
     side0 = np.sqrt((initial_area_pct/100.0)*A)

--- a/classic_seg.py
+++ b/classic_seg.py
@@ -156,6 +156,7 @@ def segment_zo1_otsu(
     min_peak_dist: int = 8,
     thresh_multiplier: float = 1.0,
     skeleton_thickness: int = 1,
+    denoise_size: int = 3,
 ) -> SegmentationResult:
     """Segment membranes using Otsu or adaptive thresholding.
 
@@ -181,9 +182,20 @@ def segment_zo1_otsu(
         Multiplier applied to Otsu threshold, by default 1.0.
     skeleton_thickness : int, optional
         Pixel thickness of the returned skeleton, by default 1.
+    denoise_size : int, optional
+        Kernel size for median filtering to remove salt-and-pepper noise,
+        by default 3. If <= 1, no median filtering is applied.
     """
 
-    blur = cv2.GaussianBlur(img_u8, (0, 0), smooth_sigma)
+    # Remove salt-and-pepper noise prior to Gaussian smoothing
+    if denoise_size and denoise_size > 1:
+        if denoise_size % 2 == 0:
+            denoise_size += 1  # kernel size must be odd
+        prep = cv2.medianBlur(img_u8, denoise_size)
+    else:
+        prep = img_u8
+
+    blur = cv2.GaussianBlur(prep, (0, 0), smooth_sigma)
     if adaptive:
         if block % 2 == 0:
             block += 1  # ensure odd

--- a/zo1_core/analysis.py
+++ b/zo1_core/analysis.py
@@ -77,6 +77,7 @@ def sample_circle(cx, cy, r, H, W):
 
 def ris_segfree(img_gray,
                 use_premask=True, premask_strength=1.0,
+                denoise_size=3, gauss_sigma=1.0,
                 smooth_window=9, z_thresh=2.0, min_sep=10,
                 initial_area_pct=10.0, max_area_pct=70.0, steps=5):
     H, W = img_gray.shape
@@ -84,6 +85,16 @@ def ris_segfree(img_gray,
     mask_used = None
     if use_premask:
         work, mask_used = apply_otsu_mask(img_gray, strength=premask_strength)
+
+    # Remove salt-and-pepper noise with median filtering
+    work_u8 = np.clip(work, 0, 255).astype(np.uint8)
+    if denoise_size and denoise_size > 1:
+        if denoise_size % 2 == 0:
+            denoise_size += 1
+        work_u8 = cv2.medianBlur(work_u8, denoise_size)
+
+    # Apply Gaussian smoothing for more stable peak detection
+    work = cv2.GaussianBlur(work_u8, (0, 0), gauss_sigma).astype(np.float32)
     A = H * W
     r0 = np.sqrt((initial_area_pct / 100.0 * A) / np.pi)
     r1 = np.sqrt((max_area_pct / 100.0 * A) / np.pi)


### PR DESCRIPTION
## Summary
- Remove isolated bright pixels with a configurable median filter before applying Gaussian smoothing in `segment_zo1_otsu`
- Add identical prefiltering and smoothing steps to RIS and TiJOR peak detection helpers for cleaner intersection counts

## Testing
- `python -m py_compile classic_seg.py zo1_core/analysis.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b499c466708326b96053fac2f1593b